### PR TITLE
Fix GCC build: not using Windows locale

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2299,7 +2299,6 @@ _Py_GetLocaleconvNumeric(struct lconv *lc,
     assert(decimal_point != NULL);
     assert(thousands_sep != NULL);
 
-#ifndef MS_WINDOWS
     int change_locale = 0;
     if ((strlen(lc->decimal_point) > 1 || ((unsigned char)lc->decimal_point[0]) > 127)) {
         change_locale = 1;
@@ -2338,11 +2337,7 @@ _Py_GetLocaleconvNumeric(struct lconv *lc,
         }
     }
 
-#define GET_LOCALE_STRING(ATTR) PyUnicode_DecodeLocale(lc->ATTR, NULL)
-#else /* MS_WINDOWS */
-/* Use _W_* fields of Windows strcut lconv */
-#define GET_LOCALE_STRING(ATTR) PyUnicode_FromWideChar(lc->_W_ ## ATTR, -1)
-#endif /* MS_WINDOWS */
+    #define GET_LOCALE_STRING(ATTR) PyUnicode_DecodeLocale(lc->ATTR, NULL)
 
     int res = -1;
 


### PR DESCRIPTION
Windows localeconv is only available for MSVC compiler.

Since our repo gives support for MinGW, it can be changed for GCC only.

Fix for my build error:
```
Python/fileutils.c:2344:60: error: 'struct lconv' has no member named '_W_decimal_point'; did you mean 'decimal_point'?
 2344 | #define GET_LOCALE_STRING(ATTR) PyUnicode_FromWideChar(lc->_W_ ## ATTR, -1)
      |                                                            ^~~
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
